### PR TITLE
Deprecate attrs_sqlalchemy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,20 @@
 attrs_sqlalchemy
 ================
 
+Deprecation
+-----------
+
+**This project is deprecated!** SQLAlchemy already manages ``__eq__`` and
+``__hash__`` based on identity within the session. This project is incompatible
+with attrs 17.1.0+ or recent versions of SQLAlchemy.
+
+If you're just looking for a nice ``__repr__`` for your SQLAlchemy models,
+consider `sqlalchemy-repr <https://pypi.org/project/sqlalchemy-repr/>`_, `repr
+<https://pypi.org/project/repr/>`_, or other packages.
+
+Legacy documentation
+--------------------
+
 .. image:: https://img.shields.io/pypi/v/attrs_sqlalchemy.svg
    :target: https://pypi.python.org/pypi/attrs_sqlalchemy
 

--- a/attrs_sqlalchemy.py
+++ b/attrs_sqlalchemy.py
@@ -3,6 +3,8 @@ Use `attrs <https://attrs.readthedocs.io>`_ to add ``__repr__``, ``__eq__``,
 ``__cmp__``, and ``__hash__`` methods according to the fields on a SQLAlchemy
 model class.
 """
+import warnings
+
 import attr
 from sqlalchemy import inspect
 
@@ -31,6 +33,8 @@ def attrs_sqlalchemy(maybe_cls=None):
     model class.
     """
     def wrap(cls):
+        warnings.warn(UserWarning('attrs_sqlalchemy is deprecated'))
+
         these = {
             name: attr.ib()
             # `__mapper__.columns` is a dictionary mapping field names on the

--- a/test_attrs_sqlalchemy.py
+++ b/test_attrs_sqlalchemy.py
@@ -8,6 +8,14 @@ from attrs_sqlalchemy import attrs_sqlalchemy
 
 class TestAttrsSqlalchemy:
 
+    def test_deprecation(self):
+        with pytest.warns(UserWarning, match='attrs_sqlalchemy is deprecated'):
+            @attrs_sqlalchemy
+            class MyModel(declarative_base()):
+                __tablename__ = 'mymodel'
+
+                id = sa.Column(sa.Integer, primary_key=True)
+
     @pytest.mark.parametrize('decorator', [attrs_sqlalchemy, attrs_sqlalchemy()])
     def test_attrs_sqlalchemy(self, decorator):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,10 @@ envlist = py27,pypy,py35,style,readme
 
 [testenv]
 deps =
-    pytest
+    pytest < 3.3
     coverage
+    attrs < 17.1.0
+    sqlalchemy < 1.1
 commands =
     coverage run -m pytest []
     coverage report


### PR DESCRIPTION
SQLAlchemy already manages `__eq__` and `__hash__` based on identity within the session. This project is incompatible with attrs 17.1.0+ or recent versions of SQLAlchemy.

If you're just looking for a nice `__repr__` for your SQLAlchemy models, consider [sqlalchemy-repr](https://pypi.org/project/sqlalchemy-repr/), [repr](https://pypi.org/project/repr/), or other packages.